### PR TITLE
Tutorials and projects page

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -1,7 +1,238 @@
-import React from 'react';
+/* eslint-disable react/jsx-props-no-spreading */
+import React, { useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import FolderIcon from '@material-ui/icons/Folder';
+import Fab from '@material-ui/core/Fab';
+import { NavLink } from 'react-router-dom';
 
-function Home() {
-  return <div>Home</div>;
+function TabPanel(props) {
+  const {
+    children, value, index, ...other
+  } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box p={0}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  );
 }
 
-export default Home;
+function a11yProps(index) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    width: 220,
+    backgroundColor: theme.palette.background.paper,
+  },
+
+  labelContainer: {
+    paddingLeft: 0,
+    paddingRight: 0,
+  },
+  ListItem: {
+    width: '100%',
+  },
+}));
+
+export default function SimpleTabs() {
+  const classes = useStyles();
+  const [value, setValue] = useState(0);
+  const [isTutorial, setIsTutorial] = useState(null);
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+    console.log(newValue);
+    if (newValue === 1) {
+      setIsTutorial(true);
+      console.log('isTutorial = true');
+    } else {
+      setIsTutorial(false);
+      console.log('isTutorial = false');
+    }
+  };
+
+  const tabStyle = {
+    minWidth: 110,
+    paddingLeft: 10,
+    paddingRight: 10,
+    backgroundColor: 'white',
+  };
+
+  if (!isTutorial) {
+    return (
+      <div className="homepage-container">
+        <div className="sidebar">
+          <div className={classes.root}>
+            <Tabs value={value} onChange={handleChange} aria-label="simple tabs example">
+              <Tab style={tabStyle} label="Tutorials" {...a11yProps(0)} />
+              <Tab style={tabStyle} label="Projects" {...a11yProps(1)} />
+            </Tabs>
+            <TabPanel value={value} index={0}>
+              <List className={classes.ListItem} component="nav" aria-label="tutorials">
+                <ListItem button onClick={() => { console.log('onClick'); }}>
+                  <ListItemIcon>
+                    <FolderIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Tutorial Module 1" />
+                </ListItem>
+                <ListItem button>
+                  <ListItemIcon>
+                    <FolderIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Tutorial Module 2" />
+                </ListItem>
+                <ListItem button>
+                  <ListItemIcon>
+                    <FolderIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Tutorial Module 3" />
+                </ListItem>
+              </List>
+            </TabPanel>
+
+          </div>
+        </div>
+        <div className="main-page">
+          <div className="main-page-title">
+            <h1>Tutorials:</h1>
+          </div>
+          <div className="lessons-container">
+            <div className="full-name-edit-btn">
+              <Fab component={NavLink}
+                to="/editor"
+                variant="extended"
+                color="primary"
+                aria-label="add"
+                className="edit-btn"
+              >
+                Lesson 1.1: Basic Commands
+              </Fab>
+            </div>
+            <div className="full-name-edit-btn">
+              <Fab variant="extended" color="primary" aria-label="add" className="edit-btn">
+                Lesson 1.2:  Data Import/Export Commands
+              </Fab>
+            </div>
+            <div className="full-name-edit-btn">
+              <Fab variant="extended" color="primary" aria-label="add" className="edit-btn">
+                Lesson 1.3: Data Transformation
+              </Fab>
+            </div>
+            <div className="full-name-edit-btn">
+              <Fab variant="extended" color="primary" aria-label="add" className="edit-btn">
+                Lesson 1.4: Data Analysis Commands
+              </Fab>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  } else {
+    return (
+      <div className="homepage-container">
+        <div className="sidebar">
+          <div className={classes.root}>
+            <Tabs value={value} onChange={handleChange} aria-label="simple tabs example">
+              <Tab style={tabStyle} label="Tutorials" {...a11yProps(0)} />
+              <Tab style={tabStyle} label="Projects" {...a11yProps(1)} />
+            </Tabs>
+            <TabPanel value={value} index={0}>
+              <List className={classes.ListItem} component="nav" aria-label="tutorials">
+                <ListItem button>
+                  <ListItemIcon>
+                    <FolderIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Tutorial Module 1" />
+                </ListItem>
+                <ListItem button>
+                  <ListItemIcon>
+                    <FolderIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Tutorial Module 2" />
+                </ListItem>
+                <ListItem button>
+                  <ListItemIcon>
+                    <FolderIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Tutorial Module 3" />
+                </ListItem>
+              </List>
+            </TabPanel>
+            <TabPanel value={value} index={1}>
+              <List component="nav" aria-label="projects">
+                <ListItem button>
+                  <ListItemIcon>
+                    <FolderIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Project Module 1" />
+                </ListItem>
+                <ListItem button>
+                  <ListItemIcon>
+                    <FolderIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Project Module 2" />
+                </ListItem>
+                <ListItem button>
+                  <ListItemIcon>
+                    <FolderIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Project Module 3" />
+                </ListItem>
+              </List>
+            </TabPanel>
+          </div>
+        </div>
+        <div className="main-page">
+          <div className="main-page-title">
+            <h1>Projects:</h1>
+          </div>
+          <div className="lessons-container">
+            <div className="full-name-edit-btn">
+              <Fab variant="extended" color="primary" aria-label="add" className="edit-btn">
+                Test Project
+              </Fab>
+            </div>
+            <div className="full-name-edit-btn">
+              <Fab variant="extended" color="primary" aria-label="add" className="edit-btn">
+                Play with data
+              </Fab>
+            </div>
+            <div className="full-name-edit-btn">
+              <Fab variant="extended" color="primary" aria-label="add" className="edit-btn">
+                Group project
+              </Fab>
+            </div>
+            <div className="full-name-edit-btn">
+              <Fab variant="extended" color="primary" aria-label="add" className="edit-btn">
+                Other stuff
+              </Fab>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -1,7 +1,0 @@
-import React from 'react';
-
-function Profile() {
-  return <div>Profile</div>;
-}
-
-export default Profile;

--- a/src/pages/signup.js
+++ b/src/pages/signup.js
@@ -47,6 +47,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
+
   },
   avatar: {
     margin: theme.spacing(1),
@@ -138,6 +139,8 @@ const SignUp = () => {
               variant="contained"
               color="primary"
               className={classes.submit}
+              component={NavLink}
+              to="/home"
             >
               Sign Up
             </Button>

--- a/src/style.scss
+++ b/src/style.scss
@@ -3,6 +3,7 @@ html {
   font-family: 'Roboto', sans-serif;
   background-color: grey;
   height: 100%;
+  margin: 0 !important;
 }
 
 .active {
@@ -28,3 +29,55 @@ html {
   padding: 20px;
   border-radius: 20px;
 }
+
+.homepage-container {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.sidebar {
+  width: 220px;
+  height: 100vh;
+  background-color: white;
+  box-shadow: 10px 0 5px -2px #888;
+
+}
+
+.MuiListItemIcon-root {
+  min-width: 40px !important;
+}
+
+.main-page {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
+  background-color: lightgrey;
+}
+
+.main-page-title {
+  margin: 20px;
+}
+
+.lessons-container {
+  width: 85%;
+}
+
+.MuiFab-label {
+  justify-content: flex-start !important;
+}
+
+.full-name-edit-btn .edit-btn {
+  width: 100%;
+  height: 100px;
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
+.listItem {
+  width: 100%;
+}
+


### PR DESCRIPTION
# Tutorials and projects page

Finished implementing a basic version of the home page. Now we have a home page with a sidebar that switches back and forth between tutorials and projects. This change is also reflected by the list of buttons on the right. 

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Referenced Issue(s)

- [17](https://github.com/dartmouth-cs52-20X/project-open-stata/issues/17)
- [18](https://github.com/dartmouth-cs52-20X/project-open-stata/issues/18)

## Screenshots/Screen Recordings
<img width="1791" alt="tutorials-project-page" src="https://user-images.githubusercontent.com/53027414/90588167-b2c70780-e176-11ea-8665-46442c6ffc0f.png">

