### PR TITLE
signin/signup are now modals

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "./node_modules/.bin/eslint src",
     "build": "yarn clean; NODE_ENV=production webpack --colors",
     "clean": "rimraf dist",
-    "deploy": "yarn build; surge -p dist -d starterpack-jakeane.surge.sh; yarn clean"
+    "deploy": "yarn build; surge -p dist -d project-open-stata.surge.sh; yarn clean"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",
@@ -52,6 +52,7 @@
     "react-redux": "^7.2.1",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
+    "react-router-modal": "^1.5.2",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0"
   }

--- a/src/app.js
+++ b/src/app.js
@@ -1,8 +1,12 @@
 import React from 'react';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import {
+  BrowserRouter as Router, Route, Switch,
+} from 'react-router-dom';
+import { ModalRoute } from 'react-router-modal';
 import './style.scss';
 import Welcome from './pages/welcome';
-import SignUp from './pages/signup';
+import SignUp from './components/signup';
+import SignIn from './components/signin';
 import Home from './pages/home';
 import CodeEditor from './pages/codeEditor';
 import Profile from './pages/profile';
@@ -17,7 +21,8 @@ const App = () => {
       <div>
         <Switch>
           <Route exact path="/" component={Welcome} />
-          <Route path="/signup" component={SignUp} />
+          <ModalRoute path="/signup" component={SignUp} />
+          <ModalRoute path="/signin" component={SignIn} />
           <Route path="/home" component={Home} />
           <Route path="/editor" component={CodeEditor} />
           <Route path="/profile" component={Profile} />

--- a/src/components/signin.js
+++ b/src/components/signin.js
@@ -1,0 +1,98 @@
+import React from 'react';
+
+import Avatar from '@material-ui/core/Avatar';
+import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+import TextField from '@material-ui/core/TextField';
+import Grid from '@material-ui/core/Grid';
+import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import Container from '@material-ui/core/Container';
+
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    marginTop: theme.spacing(8),
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  avatar: {
+    margin: theme.spacing(1),
+    backgroundColor: theme.palette.secondary.main,
+  },
+  form: {
+    width: '100%', // Fix IE 11 issue.
+    marginTop: theme.spacing(3),
+  },
+  submit: {
+    margin: theme.spacing(3, 0, 2),
+  },
+}));
+
+// should look into displaying the landing page behind the modal
+// documentation recommends removing "exact" so "/" and "/signin" both load
+// but that does not allow the modal to load
+const SignIn = () => {
+  const classes = useStyles();
+  return (
+    <div>
+      <Container component="main" maxWidth="sm" className="signin-modal">
+        <IconButton
+          type="button"
+          href="/"
+        >
+          <CloseIcon />
+        </IconButton>
+        <div className={classes.paper}>
+          <Avatar className={classes.avatar}>
+            <LockOutlinedIcon />
+          </Avatar>
+          <Typography component="h1" variant="h5">
+            Sign in
+          </Typography>
+          <form className={classes.form} noValidate>
+            <Grid container spacing={2}>
+              <Grid item xs={12}>
+                <TextField
+                  variant="outlined"
+                  required
+                  fullWidth
+                  id="email"
+                  label="Email Address"
+                  name="email"
+                  autoComplete="email"
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  variant="outlined"
+                  required
+                  fullWidth
+                  name="password"
+                  label="Password"
+                  type="password"
+                  id="password"
+                  autoComplete="current-password"
+                />
+              </Grid>
+            </Grid>
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              color="primary"
+              className={classes.submit}
+              href="/home"
+            >
+              Sign In
+            </Button>
+          </form>
+        </div>
+      </Container>
+    </div>
+  );
+};
+
+export default SignIn;

--- a/src/components/signup.js
+++ b/src/components/signup.js
@@ -1,0 +1,139 @@
+import React from 'react';
+
+import Avatar from '@material-ui/core/Avatar';
+import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+import TextField from '@material-ui/core/TextField';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
+import Link from '@material-ui/core/Link';
+import Grid from '@material-ui/core/Grid';
+import LockOutlinedIcon from '@material-ui/icons/LockOutlined';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import Container from '@material-ui/core/Container';
+
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    marginTop: theme.spacing(8),
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  avatar: {
+    margin: theme.spacing(1),
+    backgroundColor: theme.palette.secondary.main,
+  },
+  form: {
+    width: '100%', // Fix IE 11 issue.
+    marginTop: theme.spacing(3),
+  },
+  submit: {
+    margin: theme.spacing(3, 0, 2),
+  },
+}));
+
+// should look into displaying the landing page behind the modal
+// documentation recommends removing "exact" so "/" and "/signup" both load
+// but that does not allow the modal to load
+const SignUp = () => {
+  const classes = useStyles();
+  return (
+    <div>
+      <Container component="main" maxWidth="sm" className="signup-modal">
+        <IconButton
+          type="button"
+          href="/"
+        >
+          <CloseIcon />
+        </IconButton>
+        <div className={classes.paper}>
+          <Avatar className={classes.avatar}>
+            <LockOutlinedIcon />
+          </Avatar>
+          <Typography component="h1" variant="h5">
+            Sign up
+          </Typography>
+          <form className={classes.form} noValidate>
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  autoComplete="fname"
+                  name="firstName"
+                  variant="outlined"
+                  required
+                  fullWidth
+                  id="firstName"
+                  label="First Name"
+                  autoFocus
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  variant="outlined"
+                  required
+                  fullWidth
+                  id="lastName"
+                  label="Last Name"
+                  name="lastName"
+                  autoComplete="lname"
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  variant="outlined"
+                  required
+                  fullWidth
+                  id="email"
+                  label="Email Address"
+                  name="email"
+                  autoComplete="email"
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  variant="outlined"
+                  required
+                  fullWidth
+                  name="password"
+                  label="Password"
+                  type="password"
+                  id="password"
+                  autoComplete="current-password"
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <FormControlLabel
+                  control={
+                    <Checkbox value="allowExtraEmails" color="primary" />
+                  }
+                  label="I want to receive inspiration, marketing promotions and updates via email."
+                />
+              </Grid>
+            </Grid>
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              color="primary"
+              className={classes.submit}
+              href="/home"
+            >
+              Sign Up
+            </Button>
+            <Grid container justify="flex-end">
+              <Grid item>
+                <Link href="/signin" variant="body2">
+                  Already have an account? Sign in
+                </Link>
+              </Grid>
+            </Grid>
+          </form>
+        </div>
+      </Container>
+    </div>
+  );
+};
+
+export default SignUp;

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Jack Keane Starter Pack</title>
+    <title>Open Stata</title>
     <link
       href="https://fonts.googleapis.com/css?family=Roboto"
       rel="stylesheet"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable comma-dangle */
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { ModalContainer } from 'react-router-modal';
 import { Provider } from 'react-redux';
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
@@ -22,6 +23,7 @@ const store = createStore(
 ReactDOM.render(
   <Provider store={store}>
     <App />
+    <ModalContainer />
   </Provider>,
   document.getElementById('main')
 );

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
-import AppBar from '@material-ui/core/Appbar';
+import 'react-router-modal/css/react-router-modal.css';
+
+import AppBar from '@material-ui/core/AppBar';
 import Grid from '@material-ui/core/Grid';
 import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
@@ -8,6 +10,7 @@ import Person from '@material-ui/icons/Person';
 import Computer from '@material-ui/icons/Computer';
 import axios from 'axios';
 
+// placeholder, will replace with our own NavBar
 const MUIAppBar = () => {
   return (
     <AppBar position="static">
@@ -41,9 +44,13 @@ const Welcome = (props) => {
       <MUIAppBar />
       <div id="welcome-box">
         <h1>Open Stata</h1>
-        <h5>You get a Stata. You get a Stata. Everyone gets a Stata!</h5>
+        <h2>An online, open-source text editor and tutorial for learning Stata</h2>
         <IconButton component={NavLink} to="/signup">
           <Typography variant="body1">Sign Up</Typography>
+          <Person />
+        </IconButton>
+        <IconButton component={NavLink} to="/signin">
+          <Typography variant="body1">Sign In</Typography>
           <Person />
         </IconButton>
         <IconButton onClick={callAPI}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6309,6 +6309,11 @@ react-router-dom@^5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-router-modal@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/react-router-modal/-/react-router-modal-1.5.2.tgz#64fa736b0457339415785e086cf3498d5bf61536"
+  integrity sha512-q1a0KJaDI7pJbmMZV/bJYcr2BqsePOAyCgCl8xN7t5IA+3LFQyqFJwvLrMvmPnsjVKR0vaUSrqgObOslgpxs7A==
+
 react-router@5.2.0, react-router@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"


### PR DESCRIPTION
# Signin/signup are now modals

Created signin and signup components and made them modals. Clicking "sign in" or "sign up" links directly to the home page, no auth yet.

- Created signin and signup components
- Can navigate to modals from the landing page, close them to return to the landing page, or sign in/sign up for the home page

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Referenced Issue(s)

- [Issue Number #19](https://github.com/dartmouth-cs52-20X/project-open-stata/issues/19)
- [Issue Number #20](https://github.com/dartmouth-cs52-20X/project-open-stata/issues/20)