### PR TITLE
Welcome page shows editor link if authenticated

### DIFF
--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -1,16 +1,18 @@
 import React from 'react';
-import { NavLink, withRouter } from 'react-router-dom';
-import 'react-router-modal/css/react-router-modal.css';
+import { NavLink } from 'react-router-dom';
+import { connect } from 'react-redux';
 
-import AppBar from '@material-ui/core/AppBar';
-import Grid from '@material-ui/core/Grid';
+/* import AppBar from '@material-ui/core/AppBar';
+import Grid from '@material-ui/core/Grid'; */
 import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
 import Person from '@material-ui/icons/Person';
 import Computer from '@material-ui/icons/Computer';
 
+import NavBar from '../components/navbar';
+
 // placeholder, will replace with our own NavBar
-const MUIAppBar = () => {
+/* const MUIAppBar = () => {
   return (
     <AppBar position="static">
       <Grid container direction="row" justify="flex-end">
@@ -21,32 +23,41 @@ const MUIAppBar = () => {
       </Grid>
     </AppBar>
   );
-};
+}; */
 
 const Welcome = (props) => {
   return (
     <div>
-      <MUIAppBar />
+      <NavBar />
       <div id="welcome-box">
         <h1>Open Stata</h1>
         <h2>
           An online, open-source text editor and tutorial for learning Stata
         </h2>
-        <IconButton component={NavLink} to="/signup">
-          <Typography variant="body1">Sign Up</Typography>
-          <Person />
-        </IconButton>
-        <IconButton component={NavLink} to="/signin">
-          <Typography variant="body1">Sign In</Typography>
-          <Person />
-        </IconButton>
-        <IconButton component={NavLink} to="/editor">
-          <Typography variant="body1">Go to editor (for api call)</Typography>
-          <Computer />
-        </IconButton>
+        { !props.authenticated ? (
+          <div>
+            <IconButton component={NavLink} to="/signup">
+              <Typography variant="body1">Sign Up</Typography>
+              <Person />
+            </IconButton>
+            <IconButton component={NavLink} to="/signin">
+              <Typography variant="body1">Sign In</Typography>
+              <Person />
+            </IconButton>
+          </div>
+        ) : (
+          <IconButton component={NavLink} to="/editor">
+            <Typography variant="body1">Go to editor </Typography>
+            <Computer />
+          </IconButton>
+        )}
       </div>
     </div>
   );
 };
 
-export default withRouter(Welcome);
+const mapStateToProps = (reduxState) => ({
+  authenticated: reduxState.auth.authenticated,
+});
+
+export default connect(mapStateToProps, null)(Welcome);


### PR DESCRIPTION
# Welcome page links

If signed in, the welcome page shows "go to editor" instead of "sign up" and "sign in" links

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update