### PR TITLE
add submenus in sidebar

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -12,6 +12,7 @@ export const ActionTypes = {
   SAVE_DOFILE: 'SAVE_DOFILE',
   DELETE_DOFILE: 'DELETE_DOFILE',
   GET_LOGFILES: 'GET_LOGFILES',
+  GET_SINGLE_LOGFILE: 'GET_SINGLE_LOGFILE',
 };
 
 export function signinUser(user, history) {
@@ -161,7 +162,7 @@ export function saveURL(post) {
 
 export const getLogFiles = () => (dispatch) => {
   axios
-    .get('https://open-stata.herokuapp.com/api/logfiles', {
+    .get(`${ROOT_URL}/logfiles`, {
       headers: { authorization: localStorage.getItem('token') },
     })
     .then((res) => {
@@ -170,5 +171,22 @@ export const getLogFiles = () => (dispatch) => {
         type: ActionTypes.GET_LOGFILES,
         payload: res.data,
       });
+    });
+};
+
+export const getSingleLogFile = (logID) => (dispatch) => {
+  axios
+    .get(`${ROOT_URL}/logfiles/${logID}`, {
+      headers: { authorization: localStorage.getItem('token') },
+    })
+    .then((res) => {
+      console.log('response', res.data);
+      dispatch({
+        type: ActionTypes.GET_SINGLE_LOGFILE,
+        payload: res.data,
+      });
+    })
+    .catch((err) => {
+      console.error(err);
     });
 };

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,10 +1,12 @@
 import { combineReducers } from 'redux';
 import AuthReducer from './auth-reducer';
 import DoFileReducer from './dofile-reducer';
+import LogFileReducer from './logfile-reducer';
 
 const rootReducer = combineReducers({
   auth: AuthReducer,
   dofiles: DoFileReducer,
+  logfiles: LogFileReducer,
 });
 
 export default rootReducer;

--- a/src/reducers/logfile-reducer.js
+++ b/src/reducers/logfile-reducer.js
@@ -1,0 +1,20 @@
+import { ActionTypes } from '../actions';
+
+const initialState = {
+  all: [],
+  current: {},
+};
+
+const LogfileReducer = (state = initialState, action) => {
+  console.log('Action', action.type);
+  switch (action.type) {
+    case ActionTypes.GET_LOGFILES:
+      return { all: action.payload, current: state.current };
+    case ActionTypes.GET_SINGLE_LOGFILE:
+      return { all: state.all, current: action.payload };
+    default:
+      return state;
+  }
+};
+
+export default LogfileReducer;

--- a/src/style.scss
+++ b/src/style.scss
@@ -86,6 +86,10 @@ div.divider {
   width: 2px;
 }
 
+div.drawerContainer {
+  overflow: auto;
+}
+
 .homepage-container {
   margin-top: 45px;
   display: flex;
@@ -160,7 +164,7 @@ div.divider {
   position: fixed;
   height: 200px;
   width: 248px;
-  bottom: 0px;
+  bottom: 40px;
   text-align: center;
   padding-bottom: 10px;
   color: white;


### PR DESCRIPTION
# Title

Added submenu in sidebar for logs with functionality stuff

- Made collapsable submenus for do files and log files. Will also do for data files when included in backend.
- Change height of drawer so it does not render behind file upload widget
- Simplified conditional statement with file uploads

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Screenshots/Screen Recordings

<img width="1122" alt="Screen Shot 2020-08-29 at 6 22 07 PM" src="https://user-images.githubusercontent.com/52009851/91648413-8dfb4b80-ea24-11ea-99b0-db01ab642260.png">

