### PR TITLE
File and Alias Validation

### DIFF
--- a/src/pages/codeEditor.js
+++ b/src/pages/codeEditor.js
@@ -239,6 +239,7 @@ Statistics/Data Analysis`;
 
   // handles the situation where we are uploading by file
   const handleFileUpload = () => {
+    // alias cannot have whitespace
     if (alias.indexOf(' ') >= 0) {
       handleAlert('error: Alias must not contain any white space characters', 'error');
     } else if (fileToUpload && alias) {
@@ -267,6 +268,7 @@ Statistics/Data Analysis`;
 
   // handles the situation where we are uploading by URL
   const handleURLUpload = () => {
+    // alias cannot have whitespace
     if (alias.indexOf(' ') >= 0) {
       handleAlert('error: Alias must not contain any white space characters', 'error');
     } else if (urlToUpload && alias) {


### PR DESCRIPTION
# File and Alias Validation

The file/url widget will only accept files ending in .dta, .csv .xlsx .xls .pkl .hdf, and will not accept an alias with white space

- extension validation
- input validation (alias)

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

